### PR TITLE
Adds `compatible` key check to gameSupported;

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,10 @@ function install(files: string[],
 }
 
 function gameSupported(gameId: string) {
+  const game = util.getGame(gameId);
+  if (game.compatible && game.compatible["dinput"] !== undefined && !game.compatible["dinput"]) {
+    return false;
+  }
   return !['factorio', 'microsoftflightsimulator'].includes(gameId);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ function install(files: string[],
 
 function gameSupported(gameId: string) {
   const game = util.getGame(gameId);
-  if (game.compatible && game.compatible["dinput"] !== undefined && !game.compatible["dinput"]) {
+  if (game.compatible?.deployToGameDirectory === false || game.compatible?.dinput === false) {
     return false;
   }
   return !['factorio', 'microsoftflightsimulator'].includes(gameId);


### PR DESCRIPTION
This is the result of Nexus-Mods/Vortex#9665 ;

So this is the simplest method I could think of: a game could add a simple `dinput: false` to the `compatible` object and the dinput mod type would regard it as not supported entirely.

As always, open to suggestions, and if this is an acceptable solution, I can open a matching PR for the ENB mod type following the same convention.

@IDCs (for visibility)